### PR TITLE
Fix: when enable button will show content

### DIFF
--- a/src/block-button/WcbButtonPanelContent.tsx
+++ b/src/block-button/WcbButtonPanelContent.tsx
@@ -126,28 +126,34 @@ const WcbButtonPanelContent: FC<Props> = ({
 					}}
 				/>
 
-				<SelecIcon
-					iconData={icon}
-					onChange={(value) => {
-						setAttr__({
-							...panelData,
-							icon: value,
-						});
-					}}
-				/>
+				{
+					enableIcon && (
+						<>
+							<SelecIcon
+								iconData={icon}
+								onChange={(value) => {
+									setAttr__({
+										...panelData,
+										icon: value,
+									});
+								}}
+							/>
 
-				<MyRadioGroup
-					label={__("Icon position", "wcb")}
-					value={iconPosition}
-					onChange={(value) => {
-						setAttr__({
-							...panelData,
-							iconPosition: value as typeof iconPosition,
-						});
-					}}
-					hasResponsive={false}
-					plans={PLANS_DEMO}
-				/>
+							<MyRadioGroup
+								label={__("Icon position", "wcb")}
+								value={iconPosition}
+								onChange={(value) => {
+									setAttr__({
+										...panelData,
+										iconPosition: value as typeof iconPosition,
+									});
+								}}
+								hasResponsive={false}
+								plans={PLANS_DEMO}
+							/>
+						</>
+					)
+				}
 
 				<div>
 					<MyLabelControl className="mb-0">{__("Link", "wcb")}</MyLabelControl>


### PR DESCRIPTION
Before:
![Screenshot 2025-03-22 at 12 16 40](https://github.com/user-attachments/assets/11521624-9557-491c-ad35-c5bbc57df512)

After:
Button when disable
![Screenshot 2025-03-22 at 12 17 59](https://github.com/user-attachments/assets/7d6a07c0-9b4b-4426-856e-28deda0e02d3)

Enable:
![Screenshot 2025-03-22 at 12 19 04](https://github.com/user-attachments/assets/ab6872a5-5bd3-4ba4-b565-d53290c8a6cb)

[Evidence](https://share.cleanshot.com/g8rh0Xy6)